### PR TITLE
Potential fix for code scanning alert no. 5: Incorrect conversion between integer types

### DIFF
--- a/internal/api/middleware/cors.go
+++ b/internal/api/middleware/cors.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net/http"
 	"strings"
+	"strconv"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/matt0x6f/hashpost/internal/config"
@@ -26,7 +27,7 @@ func CORSMiddleware(corsConfig *config.CORSConfig) func(huma.Context, func(huma.
 			ctx.SetHeader("Access-Control-Allow-Credentials", "true")
 		}
 
-		ctx.SetHeader("Access-Control-Max-Age", string(rune(corsConfig.MaxAge)))
+		ctx.SetHeader("Access-Control-Max-Age", strconv.Itoa(corsConfig.MaxAge))
 
 		// Handle preflight OPTIONS requests
 		if ctx.Method() == "OPTIONS" {
@@ -60,7 +61,7 @@ func CORSMiddlewareHTTP(corsConfig *config.CORSConfig) func(http.Handler) http.H
 				w.Header().Set("Access-Control-Allow-Credentials", "true")
 			}
 
-			w.Header().Set("Access-Control-Max-Age", string(rune(corsConfig.MaxAge)))
+			w.Header().Set("Access-Control-Max-Age", strconv.Itoa(corsConfig.MaxAge))
 
 			// Handle preflight OPTIONS requests
 			if r.Method == "OPTIONS" {


### PR DESCRIPTION
Potential fix for [https://github.com/matt0x6F/hashpost/security/code-scanning/5](https://github.com/matt0x6F/hashpost/security/code-scanning/5)

To fix the problem, we need to ensure that the value set for the `Access-Control-Max-Age` header is a string representation of the integer value (e.g., "300"), not a Unicode character. This can be done by converting the integer to a string using `strconv.Itoa(corsConfig.MaxAge)` instead of `string(rune(corsConfig.MaxAge))`. This change should be made in both places in `internal/api/middleware/cors.go` where the header is set (lines 29 and 63). No new imports are needed, as `strconv` is already a standard library package.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
