### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/matt0x6F/hashpost/security/code-scanning/3](https://github.com/matt0x6F/hashpost/security/code-scanning/3)

To fix the problem, you should add a `permissions` block to the workflow file. The best way is to add it at the top level, just below the `name` field, so it applies to all jobs unless overridden. For this workflow, the jobs only need to read repository contents (for checkout and build/test), so the minimal required permission is `contents: read`. No jobs appear to require write access to issues, pull requests, or other resources. Edit `.github/workflows/ci.yml` to insert:

```yaml
permissions:
  contents: read
```

directly after the `name: CI` line. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
